### PR TITLE
Japanese Gen 1 and 2 Promos

### DIFF
--- a/116-japanese-promos.yaml
+++ b/116-japanese-promos.yaml
@@ -1,0 +1,2495 @@
+schema: E2
+id: '116'
+name: Unnumbered Promo Cards
+enumId: UNNUMBERED_PROMO_CARDS
+abbr: UPC
+officialCount: 100
+cards:
+- id: 116-1
+  pioId: unnumbered-1
+  enumId: SLOWPOKE_1
+  name: Slowpoke
+  nationalPokedexNumber: 79
+  number: '1'
+  types: [P]
+  superType: POKEMON
+  subTypes: BASIC
+  evolvesTo: [Slowbro, Slowking]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Headbutt
+    damage: 10
+  - cost: [P, P] 
+    name: Amnesia
+    text: Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-2
+  pioId: unnumbered-2
+  enumId: IMAKUNI?_2
+  name: Imakuni?
+  number: '2'
+  superType: TRAINER   
+  subTypes: []
+  rarity: Promo 
+  text: Your Active Pokémon is now Confused. This card cannot be put down on the field as a Pokémon.
+  artist: Takumi Akabane
+- id: 116-3
+  pioId: unnumbered-3
+  enumId: MEOWTH_3
+  name: Meowth
+  nationalPokedexNumber: 52
+  number: '3'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesTo: [Persian]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Scratch
+    damage: 10
+  - cost: [C]
+    name: Clear Profit
+    text: Flip a coin until you get tails. For each heads, draw a card.
+  weaknesses: 
+  - type: F
+    value: x2
+  resistances:
+  - type: P
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-4
+  pioId: unnumbered-4
+  enumId: HUNGRY_SNORLAX_4
+  name: Hungry Snorlax
+  nationalPokedexNumber: 143
+  number: '4'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesFrom: Munchlax
+  hp: 100
+  retreatCost: 4
+  moves:
+  - cost: [C]
+    name: Eat
+    text: Put 1 Food counter on Hungry Snorlax. You can't use this attack if Hungry Snorlax already has 2 Food counters on it.
+  - cost: [C, C, C]
+    name: Rollout
+    damage: 20+
+    text: You may remove any number of Food counters from Hungry Snorlax. If you do, this attack does 20 damage plus 30 damage for each Food counter you removed. If you don't, this attack does 20 damage.
+  weaknesses: 
+  - type: F
+    value: x2
+  resistances:
+  - type: P
+    value: '-30'
+  rarity: Promo
+  artist: Sumiyoshi Kizuki
+- id: 116-5
+  pioId: unnumbered-5
+  enumId: JYNX_5
+  name: Jynx
+  nationalPokedexNumber: 124
+  number: '5'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesFrom: Smoochum
+  evolvesTo: [Rougella]
+  hp: 60
+  retreatCost: 1 
+  moves:
+  - cost: [P]
+    name: Demon Curse
+    text: Flip a coin. If heads, put a Curse marker on the Defending Pokémon. When a Pokémon with a Curse marker on it is damaged by an attack by a Pokémon it has Weakness to, that attack’s damage is quadrupled instead of doubled. (The effect is the same if a Pokémon has multiple Curse Markers on it.) (Curse markers stay on the Pokémon as long as it remains in play.)
+  - cost: [W]
+    name: Icicle Punch
+    damage: 10 
+  weaknesses: 
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Atsuko Nishida
+- id: 116-6
+  pioId: unnumbered-6
+  enumId: CUBONE_6
+  name: Cubone
+  nationalPokedexNumber: 104
+  number: '6'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Marowak]
+  hp: 50
+  retreatCost: 1 
+  moves:
+  - cost: [C]
+    name: Bone Search
+    text: If Cubone doesn't already have a Bone counter on it, put a Bone counter on it.
+  - cost: [F]
+    name: Bone Killer
+    damage: 10+
+    text: You may remove a Bone counter from Cubone. If you do, this attack does 30 more damage.
+  weaknesses: 
+  - type: G
+    value: x2
+  resistances:
+  - type: L
+    value: '-30'
+  rarity: Promo
+  artist: Miki Tanaka
+- id: 116-7
+  pioId: unnumbered-7
+  enumId: KANGASKHAN_7
+  name: Kangaskhan 
+  nationalPokedexNumber: 115
+  number: '7'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  hp: 80
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Dizzy Punch
+    damage: 10x
+    text: Flip 2 coins. This attack does 10 damage times the number of heads.
+  - cost: [C, C, C]
+    name: Mega Punch
+    damage: 30
+  weaknesses: 
+  - type: F
+    value: x2
+  resistances:
+  - type: P
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-8
+  pioId: unnumbered-8
+  enumId: DIGLETT_8
+  name: Diglett
+  nationalPokedexNumber: 50
+  number: 8
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesTo: [Dugtrio]
+  hp: 50
+  retreatCost: 1 
+  moves:
+  - cost: [F]
+    name: Peck
+    damage: 10
+- cost: [F, C]
+    name: Trip Over
+    damage: 20+
+    text: Flip a coin. If heads, this attack does 20 damage plus 10 more damage.
+  weaknesses: 
+  - type: G
+    value: x2
+  resistances:
+  - type: L
+    value: '-30'
+  rarity: Promo
+  artist: Miki Tanaka
+- id: 116-9
+  pioId: unnumbered-9
+  enumId: DUGTRIO_9
+  name: Dugtrio
+  nationalPokedexNumber: 51
+  number: '9'
+  types: [F]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Diglett
+  hp: 80
+  retreatCost: 2 
+  abilities:
+  - type: Pokémon Power
+    name: Go Underground
+    text: As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks (both yours and your opponent's).
+  moves:
+  - cost: [F, F, F]
+    name: Earth Wave
+    damage: 30
+    text: This attack does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness or Resistance for Benched Pokémon.)
+  weaknesses: 
+  - type: G
+    value: x2
+  resistances:
+  - type: L
+    value: '-30'
+  rarity: Promo
+  artist: Miki Tanaka
+- id: 116-10
+  pioId: unnumbered-10
+  enumId: DRAGONITE_10
+  name: Dragonite
+  nationalPokedexNumber: 147
+  number: '10'
+  types: [C]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Dragonair
+  hp: 100
+  retreatCost: 2
+  abilities:
+  - type: Pokémon Power
+    name: Healing Wind
+    text: When you put Dragonite into play, remove 2 damage counters from each of your Pokémon. If a Pokémon has fewer damage counters than that, remove all of them from that Pokémon.
+  moves:
+  - cost: [C, C, C]
+    name: Slam
+    damage: 30x
+    text: Flip 2 coins. This attack does 30 damage times the number of heads.
+  resistances: 
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-11
+  pioId: unnumbered-11
+  enumId: MAGIKARP_11
+  name: Magikarp
+  nationalPokedexNumber: 129
+  number: '11'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesTo: [Gyarados]
+  hp: 30
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Trickle
+    damage: 10x
+    text: Flip 2 coins. This attack does 10 damage times the number of heads.
+  - cost: [W, W]
+    name: Dragon Rage
+    damage: 50
+    text: Flip 2 coins. If either of them is tails, this attack does nothing.
+  weaknesses: 
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-12
+  pioId: unnumbered-12
+  enumId: ANCIENT_MEW_12
+  name: Ancient Mew
+  nationalPokedexNumber: 151
+  number: '12'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 30
+  retreatCost: 2
+  moves:
+  - cost: [P, P]
+    name: Psyche
+    damage: 40
+  weaknesses: 
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Unknown
+- id: 116-13
+  pioId: unnumbered-13
+  enumId: GIOVANNI_S_NIDOKING_13
+  name: Giovanni's Nidoking
+  nationalPokedexNumber: 34
+  number: '13'
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, OWNERS_POKEMON, STAGE2]
+  evolvesFrom: Giovanni's Nidorino
+  hp: 100
+  retreatCost: 3
+  abilities:
+  - type: Pokémon Power
+    name: Command
+    text: Whenever one of your Giovanni's Nidoran♂ or Giovanni's Nidorino attacks, you may use this power. If the attack does damage to any Pokémon (including your own), it does 10 more damage to that Pokémon. If you have more than 1 Giovanni's Nidoking in play, use only 1 Command Pokémon Power for each attack.
+  moves:
+  - cost: [G, G, C, C]
+    name: Rumble
+    damage: 50
+    text: The Defending Pokémon can't retreat during your opponent's next turn.
+  weaknesses: 
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Atsuko Nishida
+- id: 116-14
+  pioId: unnumbered-14
+  enumId: KOGA_S_NINJA_GYM_14
+  name: Koga’s Ninja Gym
+  number: '14'
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Promo
+  text: Once during each player's turn (before attacking), that player may flip a coin. If heads, that player searches his or her deck for a Basic Pokémon with Koga in its name. Then, that player puts that card on his or her Bench. (A player can't do this if his or her Bench is full.) That player shuffles his or her deck afterwards.
+  artist: Keiji Kinebuchi
+- id: 116-15
+  pioId: unnumbered-15
+  enumId: EXEGGUTOR_15
+  name: Exeggutor
+  nationalPokedexNumber: 103
+  number: '15'
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Exeggcute
+  hp: 80
+  retreatCost: 2 
+  moves:
+  - cost: [C, C]
+    name: Stomp
+    damage: 20+
+    text: Flip a coin. If heads, this attack does 20 damage plus 10 more damage. If tails, this attack does 20 damage.
+  weaknesses: 
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Dr. Ooyama
+- id: 116-16
+  pioId: unnumbered-16
+  enumId: TROPICAL_WIND_16
+  name: Tropical Wind
+  number: '16'
+  superType: TRAINER
+  subTypes: []
+  rarity: Promo
+  text: Flip a coin. If heads, remove 2 damage counters from each Active Pokémon (remove 1 damage counter if a Pokémon has only 1). If tails, each Active Pokémon is now Asleep.
+  artist: Sumiyoshi Kizuki
+- id: 116-17
+  pioId: unnumbered-17
+  enumId: HAMA-CHAN_S_SLOWKING_17
+  name: Hama-chan's Slowking 
+  nationalPokedexNumber: 199
+  number: '17'
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Slowpoke
+  hp: 70
+  retreatCost: 1 
+  moves:
+  - cost: [P]
+    name: I'm In Trouble
+    text: Both the Defending Pokémon and Hama-chan's Slowking are now Confused.
+  - cost: [C, C]
+    name: Corkscrew Punch
+    damage: 20
+  weaknesses: 
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Masatoshi Hamada
+- id: 116-18
+  pioId: unnumbered-18
+  enumId: IMAKUNI?_S_DODUO_18
+  name: Imakuni's Doduo
+  nationalPokedexNumber: 84
+  number: '18'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Dodrio]
+  hp: 50
+  retreatCost: 0
+  abilities: 
+  - type: Pokémon Power
+    name: Frenzied Escape
+    text: When Doduo retreats, hold this card and throw it, because Doduo is running away. Throw the card horizontally witha  snap to get the furthest distance!
+  moves:
+  - cost: [C, C]
+    name: Harmonize
+    damage: 30
+  weaknesses: 
+  - type: L
+    value: x2
+  resistances: 
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Imakuni?
+- id: 116-19
+  pioId: unnumbered-19
+  enumId: ______S_CHANSEY_19
+  name: _____'s Chansey
+  nationalPokedexNumber: 113
+  number: '19'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesFrom: Happiny
+  evolvesTo: [Blissey]
+  hp: 90
+  retreatCost: 1 
+  moves:
+  - cost: [C]
+    name: Lucky Egg
+    text: Flip a coin. If heads, draw two cards. If tails, shuffle two cards from your hand into your deck. (If you have fewer than 2 cards, shuffle all of them into your deck.)
+  - cost: [C, C, C]
+    name: Lucky Punch
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 damage plus 30 more damage.
+  weaknesses: 
+  - type: F
+    value: x2
+  resistances: 
+  - type: P
+    value: '-30'
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-20
+  pioId: unnumbered-20
+  enumId: MISTY_S_TREATMENT_20
+  name: Misty's Treatment
+  number: '20'
+  superType: TRAINER
+  subTypes: []
+  rarity: Promo
+  text: Remove up to 3 damage counters from 1 of your Basic Pokémon named Lapras in play (all of them if there are less than 3).
+  artist: Toshinao Aoki
+- id: 116-21
+  pioId: unnumbered-21
+  enumId: MURKROW_21
+  name: Murkrow
+  nationalPokedexNumber: 198
+  number: '21'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesTo: [Honchkrow]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Peck
+    damage: 10
+  - cost: [D, C]
+    name: Pursuit
+    damage: 20
+    text: During your opponent's next turn, if the Defending Pokémon tries to retreat, do 10 damage to it. (Don't apply Weakness or Resistance.)
+  resistances: 
+  - type: P
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-22
+  pioId: unnumbered-22
+  enumId: WOOPER_22
+  name: Wooper
+  nationalPokedexNumber: 194
+  number: '22'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Quagsire]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Tail Whip
+    text: Flip a coin. If heads, the Defending Pokémon can't attack Wooper during your opponent's next turn. (Benching or evolving either Pokémon ends this effect.)
+  - cost: [W]
+    name: Water Gun
+    damage: 10+
+    text: Does 10 damage plus 10 more damage for each Water Energy attached to Wooper but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.
+  weaknesses: 
+  - type: G
+    value: x2
+  resistances: 
+  - type: L
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-23
+  pioId: unnumbered-23
+  enumId: STEELIX_23
+  name: Steelix
+  nationalPokedexNumber: 208
+  number: '23'
+  types: [M]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1] 
+  evolvesFrom: Onix
+  hp: 100
+  retreatCost: 4
+  moves:
+  - cost: [M]
+    name: Metal Crash
+    damage: 50
+    text: Flip a coin. If tails, this attack does nothing. Either way, you can't use this attack during your next turn.
+  - cost: [F, C]
+    name: Rumble
+    damage: 20
+    text: The Defending Pokémon can't retreat during your opponent's next turn.
+  weaknesses: 
+  - type: R
+    value: x2
+  resistances: 
+  - type: G
+    value: '-30'
+  rarity: Promo
+  artist: Benimaru Itoh
+- id: 116-24
+  pioId: unnumbered-24
+  enumId: PORYGON_24
+  name: Porygon
+  nationalPokedexNumber: 137
+  number: '24'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Porygon2]
+  hp: 50
+  retreatCost: 1 
+  moves:
+  - cost: [C]
+    name: All Clear
+    text: All Pokémon Powers stop working during this attack. Discard all Trainer cards in play. If any Pokémon in play is Asleep, Confused, Paralyzed, or Poisoned, remove all of those effects from that Pokémon. Remove all counters and markers except damage counters from any Pokémon with them on it.
+  - cost: [C, C]
+    name: Hyper Conversion
+    text: Choose a type (other than Colorless) and 1 of your opponent's Pokémon. Put a Coloring counter on that Pokémon. That Pokémon is now the type you chose. (A Pokémon can have only 1 Coloring counter on it at a time.)
+  weaknesses: 
+  - type: F
+    value: x2
+  resistances: 
+  - type: R
+    value: '-30'
+  rarity: Promo
+  artist: Tomoaki Imakuni
+- id: 116-25
+  pioId: unnumbered-25
+  enumId: DANCE!_NEO_IMAKUNI?_25
+  name: Dance! Neo Imakuni?
+  number: '25'
+  superType: TRAINER
+  subTypes: []
+  rarity: Promo
+  text: Your Active Pokémon is now Asleep, Confused, Paralyzed, or Poisoned (your choice). You can't play Imakuni? as a Pokémon.
+  artist: Tomoaki Imakuni
+- id: 116-26
+  pioId: unnumbered-26
+  enumId: CHARIZARD_26
+  name: Charizard
+  nationalPokedexNumber: 6
+  number: '26'
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Charmeleon
+  hp: 120
+  retreatCost: 3
+  abilities:
+  - type: Pokémon Power
+    name: Fire Raise
+    text: Once during your turn (before your attack), you may take up to 2 [R] Energy cards attached to your other Pokémon and attach them to Charizard. This power can't be used if Charizard is Asleep, Confused, or Paralyzed.
+  moves:
+  - cost: [R, R, R, R]
+    name: Fire Spin
+    damage: 100
+    text: Discard 2 Energy cards attached to Charizard in order to use this attack.
+  weaknesses: 
+  - type: W
+    value: x2
+  resistances: 
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-27
+  pioId: unnumbered-27
+  enumId: MARILL_27
+  name: Marill
+  nationalPokedexNumber: 183
+  number: '27'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesTo: [Azumarill]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Rebound
+    text: During your next turn, Marill's Jump On attack's base damage is tripled.
+  - cost: [C, C]
+    name: Jump On
+    damage: 10
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  weaknesses: 
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Ryuta Kusumi, CR CG gangs
+- id: 116-28
+  pioId: unnumbered-28
+  enumId: TOGEPI_28
+  name: Togepi
+  nationalPokedexNumber: 175
+  number: '28'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesTo: [Togetic]
+  hp: 40
+  retreatCost: 1 
+  moves:
+  - cost: [C]
+    name: Run Around
+    damage: 10
+    text: Switch Togepi with 1 of your Benched Pokémon, if any.
+  resistances: 
+  - type: P
+    value: '-30'
+  rarity: Promo
+  artist: Ryuta Kusumi, CR CG gangs
+- id: 116-29
+  pioId: unnumbered-29
+  enumId: UNOWN_R_29
+  name: Unown R
+  nationalPokedexNumber: 201
+  number: '29'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  hp: 40
+  retreatCost: 1
+  abilities:
+  - type: Pokémon Power
+    name: Resassure
+    text: When you play Unown [R] from your hand, you may remove all damage counters from all of your Pokémon with Unown in their names.
+  moves:
+  - cost: [P, C]
+    name: Hidden Power
+    damage: 20
+  weaknesses: 
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Hideki Kazama
+- id: 116-30
+  pioId: unnumbered-30
+  enumId: SMOOCHUM_30
+  name: Smoochum
+  nationalPokedexNumber: 238
+  number: '30'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BABY, BASIC]
+  evolvesTo: [Jynx]
+  hp: 30
+  retreatCost: 0
+  moves:
+  - cost: [C]
+    name: Blown Kiss
+    text: Put 1 damage counter on 1 of your opponent’s Pokémon.
+  rarity: Promo
+  text:
+  - If this Baby Pokémon is your Active Pokémon and your opponent tries to attack,
+    your opponent flips a coin (before doing anything else required in order to use
+    that attack). If tails, your opponent's turn ends without an attack.
+  artist: Sumiyoshi Kizuki
+- id: 116-31
+  pioId: unnumbered-31
+  enumId: DUNSPARCE_31
+  name: Dunsparce
+  nationalPokedexNumber: 206
+  number: '31'   
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesTo: [Dudunsparce]
+  hp: 40
+  retreatCost: 1 
+  moves:
+  - cost: [C]
+    name: Paralyzing Gaze
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  - cost: [C, C]
+    name: Drill Tail
+    damage: 10+
+    text: Flip a coin. If heads, this attach does 10 damage plus 20 more damage.
+  weaknesses: 
+  - type: F
+    value: x2
+  resistances: 
+  - type: R
+    value: '-30'
+  rarity: Promo
+  artist: Atsuko Nishida
+- id: 116-32
+  pioId: unnumbered-32
+  enumId: DARK_IVYSAUR_32
+  name: Dark Ivysaur
+  nationalPokedexNumber: 2
+  number: '32'   
+  types: [G]
+  superType: POKEMON
+  subTypes: [DARK_POKEMON, EVOLUTION, STAGE1]
+  evolvesFrom: Bulbasaur 
+  evolvesTo: [Dark Venusaur]
+  hp: 50
+  retreatCost: 2
+  abilities:
+  - type: Pokémon Power
+    name: Vine Pull
+    text: Once during your turn when Dark Ivysaur retreats, choose 1 of your opponent's Benched Pokémon and switch it with his or her Active Pokémon.
+  moves:
+  - cost: [G, G]
+    name: Fury Strikes 
+    text: Your opponent puts 3 markers onto his or her Pokémon (divided as he or she chooses). (More than 1 marker can be put on the same Pokémon.) Then, this attack does 10 damage to each Pokémon for each marker on it. Don't apply Weakness and Resistance. Remove the markers at the end of the turn.
+  weaknesses: 
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Shin-ichi Yoshida
+- id: 116-33
+  pioId: unnumbered-33
+  enumId: DARK_VENUSAUR_33
+  name: Dark Venusaur
+  nationalPokedexNumber: 3
+  number: '33'   
+  types: [G]
+  superType: POKEMON
+  subTypes: [DARK_POKEMON, EVOLUTION, STAGE2] 
+  evolvesFrom: Dark Ivysaur
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [G, G, G]
+    name: Horrid Pollen
+    damage: 30
+    text: Flip 2 coins. If 1 is heads, the Defending Pokémon is now Asleep and Poisoned. If both are heads, the Defending Pokémon is now Confused and Poisoned. If both are tails, the Defending Pokémon is now Paralyzed and Poisoned.
+  weaknesses: 
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Shin-ichi Yoshida
+- id: 116-34
+  pioId: unnumbered-34
+  enumId: GREAT_ROCKET_S_MEWTWO_34
+  name: Great Rocket's Mewtwo
+  nationalPokedexNumber: 150
+  number: '34'   
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, OWNERS_POKEMON]
+  hp: 70
+  retreatCost: 2
+  abilities:
+  - type: Pokémon Power
+    name: Dark Wave
+    text: Whenever 1 of your Pokémon with Dark in its name does damage to any Pokémon with an attack, flip a coin. If heads, flip another coin. If the second coin is heads, that attack does 20 more damage. If the second coin is tails, that attack does 10 more damage. If you have more than 1 Great Rocket's Mewtwo in play, use only 1 Dark Wave for an attack. This power stops working while Great Rocket's Mewtwo is Asleep, Confused, or Paralyzed.
+  moves:
+  - cost: [P, P]
+    name: Dark Amplification
+    damage: 20+
+    text: Flip a number of coins equal to the number of Pokémon with Dark in their names on your Bench. This attack does 20 damage plus 20 damage times the number of heads.
+  weaknesses: 
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Shin-ichi Yoshida
+- id: 116-35
+  pioId: unnumbered-35
+  enumId: LUGIA_35
+  name: Lugia
+  nationalPokedexNumber: 249
+  number: '35'   
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  hp: 100
+  retreatCost: 2
+  moves:
+  - cost: [C, C, C]
+    name: Aeroblast
+    damage: 20+
+    text: Flip 2 coins. This attack does 20 damage plus 20 more damage for each heads.
+  weaknesses: 
+  - type: P
+    value: x2
+  resistances: 
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-36
+  pioId: unnumbered-36
+  enumId: DARK FEAROW_36
+  name: Dark Fearow
+  nationalPokedexNumber: 22
+  number: '36'   
+  types: [C]
+  superType: POKEMON
+  subTypes: [DARK_POKEMON, EVOLUTION, STAGE1]
+  evolvesFrom: Spearow
+  hp: 60
+  retreatCost: 0
+  moves:
+  - cost: [C]
+    name: Fly High
+    text: During your next turn, Dark Fearow's Drill Dive attack's base damage is doubled.
+  - cost: [C, C]
+    name: Drill Dive
+    damage: 40
+    text: During your next turn, you can't use this attack and Dark Fearow can't retreat.
+  weaknesses: 
+  - type: L
+    value: x2
+  resistances: 
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Sumiyoshi Kizuki
+- id: 116-37
+  pioId: unnumbered-37
+  enumId: BELLOSOM_37
+  name: Bellossom
+  nationalPokedexNumber: 182
+  number: '37'   
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Gloom
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [G, G, G]
+    name: Floral Spin
+    damage: 30
+    text: Flip a coin. If heads, the Defending Pokémon is now Asleep. If tails, switch Bellossom with 1 of your Benched Pokémon, if any.
+  weaknesses: 
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Naoyo Kimura
+- id: 116-38
+  pioId: unnumbered-38
+  enumId: SHINING_MEW_38
+  name: Shining Mew
+  nationalPokedexNumber: 151 
+  number: '38'   
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, SHINING_POKEMON]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Flash Search
+    text: Look at the top 3 cards from your deck. Choose 1 card from those cards, show it to your opponent, then put it into your hand. Shuffle the rest into your deck.
+  - cost: [P, R]
+    name: Mystic Fire
+    damage: 20
+    text: Discard 1 [R] Energy card attached to Shining Mew in order to flip a coin. If heads, the Defending Pokémon is now Confused. If tails, the Defending Pokémon is now Asleep. If you can't discard Energy cards, this attack does nothing (not even damage).
+  weaknesses: 
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Hironobu Yoshida
+- id: 116-39
+  pioId: unnumbered-39
+  enumId: BULBASAUR_39
+  name: Bulbasaur
+  nationalPokedexNumber: 1
+  number: '39'   
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ivysaur]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Tackle
+    damage: 10
+  - cost: [G, G]
+    name: Razor Leaf
+    damage: 30
+  weaknesses: 
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Mitsuhiro Arita
+- id: 116-40
+  pioId: unnumbered-40
+  enumId: RAICHU_40
+  name: Raichu
+  nationalPokedexNumber: 26
+  number: '40'   
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Pikachu
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Quick Attack
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 damage plus 20 more damage.
+  - cost: [L, L, L]
+    name: Thunderbolt
+    damage: 60
+    text: Discard all Energy cards attached to Raichu.
+  weaknesses: 
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Yukiko Baba
+- id: 116-41
+  pioId: unnumbered-41
+  enumId: MEOWTH_41
+  name: Meowth
+  nationalPokedexNumber: 52
+  number: '41'   
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Persian]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Bite
+    damage: 10
+  - cost: [C, C]
+    name: Fury Swipes
+    damage: 10x
+    text: Flip 3 coins. This attack does 10 damage times the number of heads.
+  weaknesses: 
+  - type: F
+    value: x2
+  resistances: 
+  - type: R
+    value: '-30'
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-42
+  pioId: unnumbered-42
+  enumId: IVYSAUR_42
+  name: Ivysaur
+  nationalPokedexNumber: 2
+  number: '42'   
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Bulbasaur
+  evolvesTo: [Venusaur]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [G, G]
+    name: Leech Seed
+    damage: 20
+    text: Unless all damage from this attack is prevented, you may remove one damage counter from Ivysaur.
+  - cost: [G, G, C]
+    name: Vine Whip
+    damage: 40
+  weaknesses: 
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Mitsuhiro Arita
+- id: 116-43
+  pioId: unnumbered-43
+  enumId: ELECTABUZZ_43
+  name: Electabuzz
+  nationalPokedexNumber: 125
+  number: '43'   
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesFrom: Elekid
+  evolvesTo: [Electivire]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [L, L, C]
+    name: Thundershock
+    damage: 30
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  weaknesses: 
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Yukiko Baba
+- id: 116-44
+  pioId: unnumbered-44
+  enumId: JYNX_44
+  name: Jynx
+  nationalPokedexNumber: 124	
+  number: '44'   
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesFrom: Smoochum
+  evolvesTo: [Rougella]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Pound
+    damage: 10
+  - cost: [P, C]
+    name: Doubleslap
+    damage: 20x
+    text: Flip 2 coins. This attack does 20 damage times the number of heads.
+  weaknesses: 
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Miki Tanaka
+- id: 116-45
+  pioId: unnumbered-45
+  enumId: KOFFING_45
+  name: Koffing
+  nationalPokedexNumber: 109
+  number: '45'   
+  types: [G] 
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Weezing]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Poison Gas
+    damage: 10
+    text: Flip a coin. If heads, the Defending Pokémon is now Poisoned.
+  - cost: [G, G]
+    name: Confusion Gas
+    damage: 20
+    text: Flip a coin. If heads, the Defending Pokémon is now Confused.
+  weaknesses: 
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Nobuyuki Habu
+- id: 116-46
+  pioId: unnumbered-46
+  enumId: WARTORTLE_46
+  name: Wartortle
+  nationalPokedexNumber: 8
+  number: '46'   
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Squirtle   
+  evolvesTo: [Blastoise]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Bubble
+    damage: 10
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  - cost: [W, W]
+    name: Surf
+    damage: 30
+  weaknesses: 
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Sumiyoshi Kizuki
+- id: 116-47
+  pioId: unnumbered-47
+  enumId: SPEAROW_47
+  name: Spearow
+  nationalPokedexNumber: 21
+  number: '47'   
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Fearow]
+  hp: 40
+  retreatCost: 0
+  moves:
+  - cost: [C]
+    name: Peck
+    damage: 10
+  - cost: [C, C]
+    name: Wing Attack
+    damage: 20
+  weaknesses: 
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+  - value: '-30'
+  rarity: Promo
+  artist: Shin-ichi Yoshida
+- id: 116-48
+  pioId: unnumbered-48
+  enumId: SQUIRTLE_48
+  name: Squirtle
+  nationalPokedexNumber: 7
+  number: '48'   
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Wartortle]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Bite
+    damage: 10
+  - cost: [W, W]
+    name: Skull Bash
+    damage: 20
+  weaknesses: 
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Sumiyoshi Kizuki
+- id: 116-49
+  pioId: unnumbered-49
+  enumId: GROWLITHE_49
+  name: Growlithe
+  nationalPokedexNumber: 58
+  number: '49'   
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Arcanine]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Lunge
+    damage: 20
+    text: Flip a coin. If tails, this attack does nothing.
+  - cost: [R, C]
+    name: Ember
+    damage: 30
+    text: Discard a [R] Energy card attached to Growlithe or this attack does nothing.
+  weaknesses: 
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-50
+  pioId: unnumbered-50
+  enumId: ARCANINE_50
+  name: Arcanine
+  nationalPokedexNumber: 59
+  number: '50'   
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Growlithe
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [R, R, C]
+    name: Take Down
+    damage: 50
+    text: Arcanine does 20 damage to itself.
+  weaknesses: 
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-51
+  pioId: unnumbered-51
+  enumId: MAGMAR_51
+  name: Magmar
+  nationalPokedexNumber: 126
+  number: '51'   
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesFrom: Magby
+  evolvesTo: [Magmortar]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Fire Punch
+    damage: 20
+  - cost: [R, R]
+    name: Smog
+    damage: 20
+    text: Flip a coin. If heads, the Defending Pokémon is now Poisoned.
+  weaknesses: 
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Shin-ichi Yoshida
+- id: 116-52
+  pioId: unnumbered-52
+  enumId: CHIKORITA_52
+  name: Chikorita
+  nationalPokedexNumber: 152
+  number: '52'   
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesTo: [Bayleef]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Tackle
+    damage: 10
+  - cost: [G, C]
+    name: Razor Leaf
+    damage: 20
+  weaknesses: 
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-53
+  pioId: unnumbered-53
+  enumId: SUNKERN_53
+  name: Sunkern
+  nationalPokedexNumber: 191
+  number: '53'   
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Sunflora]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Ram
+    damage: 10
+  weaknesses: 
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-54
+  pioId: unnumbered-54
+  enumId: TEDDIURSA_54
+  name: Teddiursa
+  nationalPokedexNumber: 216
+  number: '54'   
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ursaring]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Scratch
+    damage: 10
+  - cost: [C, C]
+    name: Fury Swipes
+    damage: 10x
+    text: Flip 3 coins. This attack does 10 damage times the number of heads.
+  weaknesses: 
+  - type: F
+    value: x2
+  resistances:
+  - type: P
+  - value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-55
+  pioId: unnumbered-55
+  enumId: QUILAVA_55
+  name: Quilava
+  nationalPokedexNumber: 156
+  number: '55'   
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Cyndaquil  
+  evolvesTo: [Typhlosion]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Tackle
+    damage: 20
+  - cost: [R, R, C]
+    name: Flamethrower
+    damage: 50
+    text: Discard 1 [R] Energy card attached to Quilava in order to use this attack.
+  weaknesses: 
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-56
+  pioId: unnumbered-56
+  enumId: CYNDAQUIL_56
+  name: Cyndaquil
+  nationalPokedexNumber: 155
+  number: '56'   
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesTo: [Quilava]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Firebreathing
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 damage plus 10 more damage.
+  weaknesses: 
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-57
+  pioId: unnumbered-57
+  enumId: BAYLEEF_57
+  name: Bayleef
+  nationalPokedexNumber: 153
+  number: '57'   
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Chikorita
+  evolvesTo: [Meganium]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Tackle
+    damage: 20
+  - cost: [G, G, C]
+    name: Sleep Powder
+    damage: 30
+    text: The Defending Pokémon is now Asleep.
+  weaknesses: 
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-58
+  pioId: unnumbered-58
+  enumId: MAGBY_58
+  name: Magby
+  nationalPokedexNumber: 240
+  number: '58'   
+  types: [R]
+  superType: POKEMON
+  subTypes: [BABY, BASIC] 
+  evolvesTo: [Magmar]
+  hp: 30
+  retreatCost: 0
+  moves:
+  - cost: [C]
+    name: Punch
+    damage: 10
+  rarity: Promo
+  text:
+  - If this Baby Pokémon is your Active Pokémon and your opponent tries to attack,
+    your opponent flips a coin (before doing anything else required in order to use
+    that attack). If tails, your opponent's turn ends without an attack.
+  artist: Kagemaru Himeno
+- id: 116-59
+  pioId: unnumbered-59
+  enumId: GEODUDE_59
+  name: Geodude
+  nationalPokedexNumber: 74
+  number: '59'   
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC] 
+  evolvesTo: [Graveler]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [F, C]
+    name: Stone Avalanche
+    damage: 10
+    text: Does 10 damage to 1 of your opponent's Benched Pokémon, if any. (Don't apply Weakness or Resistance for Benched Pokémon.)
+  weaknesses: 
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-60
+  pioId: unnumbered-60
+  enumId: SKARMORY_60
+  name: Skarmory
+  nationalPokedexNumber: 227
+  number: '60'   
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Peck
+    damage: 10
+  - cost: [M, C]
+    name: Metal Slash
+    damage: 30
+    text: This Pokémon can't attack during your next turn.
+  weaknesses: 
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+  - value: '-30'
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-61
+  pioId: unnumbered-61
+  enumId: MARILL_61
+  name: Marill
+  nationalPokedexNumber: 183
+  number: '61'   
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Azumarill]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Tackle
+    damage: 10
+  - cost: [C, C]
+    name: Rollout
+    damage: 20
+  weaknesses: 
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Atsuko Nishida
+- id: 116-62
+  pioId: unnumbered-62
+  enumId: NOCTOWL_62
+  name: Hoothoot
+  nationalPokedexNumber: 163
+  number: '62'   
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Noctowl]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Risky Kick
+    damage: 20
+    text: Flip a coin. If tails, this attack does nothing
+  weaknesses: 
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+  - value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-63
+  pioId: unnumbered-63
+  enumId: CROCONAW_63
+  name: Croconaw
+  nationalPokedexNumber: 159
+  number: '63'   
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Totodile  
+  evolvesTo: [Feraligatr]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Slash
+    damage: 20
+  - cost: [W, C, C]
+    name: Bite
+    damage: 40
+  weaknesses: 
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Atsuko Nishida
+- id: 116-64
+  pioId: unnumbered-64
+  enumId: REMORAID_64
+  name: Remoraid 
+  nationalPokedexNumber: 223
+  number: '64'   
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Octillery]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Water Gun
+    damage: 10+
+    text: Does 10 damage plus 10 more damage for each Water Energy attached to Remoraid but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.
+  weaknesses: 
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori 
+- id: 116-65
+  pioId: unnumbered-65
+  enumId: TOTODILE_65
+  name: Totodile
+  nationalPokedexNumber: 158
+  number: '65'   
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Croconaw]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Scratch
+    damage: 20
+  - cost: [W, C]
+    name: Bite
+    damage: 20
+  weaknesses: 
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Atsuko Nishida
+- id: 116-66
+  pioId: unnumbered-66
+  enumId: QWILFISH_66
+  name: Qwilfish
+  nationalPokedexNumber: 211
+  number: '66'   
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [W, C]
+    name: Poison Sting
+    damage: 20
+    text: Flip a coin. If heads, the Defending Pokémon is now Poisoned.
+  weaknesses: 
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-67
+  pioId: unnumbered-67
+  enumId: PICHU_67
+  name: Pichu
+  nationalPokedexNumber: 172
+  number: '67'   
+  types: [L]
+  superType: POKEMON
+  subTypes: [BABY, BASIC] 
+  evolvesTo: [Pikachu]
+  hp: 30
+  retreatCost: 0
+  moves:
+  - cost: [C]
+    name: Pound
+    damage: 10
+  rarity: Promo
+  text:
+  - If this Baby Pokémon is your Active Pokémon and your opponent tries to attack,
+    your opponent flips a coin (before doing anything else required in order to use
+    that attack). If tails, your opponent's turn ends without an attack.
+  artist: Atsuko Nishida
+- id: 116-card#here
+  pioId: unnumbered-68
+  enumId: ABRA_68
+  name: Abra
+  nationalPokedexNumber: 63
+  number: '68'   
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Kadabra]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Pound
+    damage: 10
+  - cost: [P]
+    name: Destructive Beam
+    damage: 10
+    text: Flip a coin. If heads, discard an Energy card attached to the Defending Pokémon.
+  weaknesses: 
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Atsuko Nishida
+- id: 116-69
+  pioId: unnumbered-69
+  enumId: VENUSAUR_69
+  name: Venusaur
+  nationalPokedexNumber: 3
+  number: '69'
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Ivysaur
+  hp: 100
+  retreatCost: 2
+  abilities:
+  - type: Pokémon Power
+    name: Energy Trans
+    text: As often as you like during your turn (before your attack), you may take
+      1 [G] Energy card attached to 1 of your Pokémon and attach it to a different
+      one. This power can't be used if Venusaur is Asleep, Confused, or Paralyzed.
+  moves:
+  - cost: [G, G, G, G]
+    name: Solarbeam
+    damage: '60'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-70
+  pioId: unnumbered-70
+  enumId: CHARIZARD_70
+  name: Charizard
+  nationalPokedexNumber: 6
+  number: '70'
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Charmeleon
+  hp: 120
+  retreatCost: 3
+  abilities:
+  - type: Pokémon Power
+    name: Energy Burn
+    text: As often as you like during your turn (before your attack), you may turn
+      all Energy attached to Charizard into [R] for the rest of the turn. This power
+      can't be used if Charizard is Asleep, Confused, or Paralyzed.
+  moves:
+  - cost: [R, R, R, R]
+    name: Fire Spin
+    damage: '100'
+    text: Discard 2 Energy cards attached to Charizard in order to use this attack.
+  weaknesses:
+  - type: W
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-71
+  pioId: unnumbered-71
+  enumId: BLASTOISE_71
+  name: Blastoise
+  nationalPokedexNumber: 9
+  number: '71'
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Wartortle
+  hp: 100
+  retreatCost: 3
+  abilities:
+  - type: Pokémon Power
+    name: Rain Dance
+    text: As often as you like during your turn (before your attack), you may attach
+      1 [W] Energy Card to 1 of your [W] Pokémon. (This doesn't use up your 1 Energy
+      card attachment for the turn.) This power can't be used if Blastoise is Asleep,
+      Confused, or Paralyzed.
+  moves:
+  - cost: [W, W, W]
+    name: Hydro Pump
+    damage: 40+
+    text: Does 40 damage plus 10 more damage for each [W] Energy attached to Blastoise
+      but not used to pay for this attack's Energy cost. Extra [W] Energy after the
+      2nd doesn't count.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-72
+  pioId: unnumbered-72
+  enumId: BROCK_S_ONIX_72
+  name: Brock's Onix
+  nationalPokedexNumber: 95
+  number: '72'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, OWNERS_POKEMON]
+  hp: 100
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Bellow
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  - cost: [F, F, C]
+    name: Rock Throw
+    damage: '30'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-73
+  pioId: unnumbered-73
+  enumId: MISTY_S_STARYU_73
+  name: Misty's Staryu
+  nationalPokedexNumber: 120
+  number: '73'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, OWNERS_POKEMON]
+  evolvesTo: [Misty's Starmie]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Star Boomerang
+    damage: '20'
+    text: Flip a coin. If heads, return Misty's Staryu and all cards attached to it
+      to your hand. (Either way, this attack does its damage.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-74
+  pioId: unnumbered-74
+  enumId: FARFETCHD
+  name: Farfetch'd
+  nationalPokedexNumber: 83
+  number: '74'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Leek Slap
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing. Either way, you can't use
+      this attack again as long as Farfetch'd stays in play (even putting Farfetch'd
+      on the Bench won't let you use it again).
+  - cost: [C, C, C]
+    name: Pot Smash
+    damage: '30'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Tomokazu Komiya
+- id: 116-75
+  pioId: unnumbered-75
+  enumId: LT__SURGE_S_ELECTABUZZ_75
+  name: Lt. Surge's Electabuzz
+  nationalPokedexNumber: 125
+  number: '75'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, OWNERS_POKEMON]
+  hp: 60
+  retreatCost: 2
+  moves:
+  - cost: [L]
+    name: Charge
+    text: Take up to 2 [L] Energy cards from your discard pile and attach them to
+      Lt. Surge's Electabuzz.
+  - cost: [L, L]
+    name: Electric Current
+    damage: '20'
+    text: Take 1 [L] Energy card attached to Lt. Surge's Electabuzz and attach it
+      to 1 of your Benched Pokémon. If you have no Benched Pokémon, discard that Energy
+      card.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Atsuko Nishida
+- id: 116-76
+  pioId: unnumbered-76
+  enumId: ERIKA_S_DRATINI_76
+  name: Erika's Dratini
+  nationalPokedexNumber: 147
+  number: '76'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, OWNERS_POKEMON]
+  evolvesTo: [Erika's Dragonair]
+  hp: 40
+  retreatCost: 1
+  abilities:
+  - type: Pokémon Power
+    name: Strange Barrier
+    text: Whenever an attack by a Basic Pokémon (including your own) does 20 or more
+      damage to Erika's Dratini (after applying Weakness and Resistance), reduce that
+      damage to 10. (Any other effects of attacks still happen.) This power stops
+      working while Erika's Dratini is Asleep, Confused, or Paralyzed.
+  moves:
+  - cost: [C, C]
+    name: Tail Strike
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if
+      tails, this attack does 10 damage.
+  resistances:
+  - type: P
+    value: '-30'
+  rarity: Promo
+  artist: Atsuko Nishida
+- id: 116-77
+  pioId: unnumbered-77
+  enumId: BROCK_S_MANKEY_77
+  name: Brock's Mankey
+  nationalPokedexNumber: 56
+  number: '77'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, OWNERS_POKEMON]
+  evolvesTo: [Brock's Primeape]
+  hp: 40
+  retreatCost: 0
+  moves:
+  - cost: [C]
+    name: Fidget
+    text: Shuffle your deck.
+  - cost: [F, C]
+    name: Karate Chop
+    damage: 40-
+    text: Does 40 damage minus 10 damage for each damage counter on Brock's Mankey.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-78
+  pioId: unnumbered-78
+  enumId: ERIKA_S_BULBASAUR_78
+  name: Erika's Bulbasaur
+  nationalPokedexNumber: 1
+  number: '78'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, OWNERS_POKEMON]
+  evolvesTo: [Erika's Ivysaur]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G]
+    name: Sleep Seed
+    damage: '10'
+    text: The Defending Pokémon is now Asleep.
+  - cost: [G, G]
+    name: Errand-Running
+    text: Flip a coin. If heads, you may search your deck for a Trainer card. Show
+      it to your opponent and put it into your hand. Shuffle your deck afterward.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-79
+  pioId: unnumbered-79
+  enumId: MISTY_S_TENTACOOL_79
+  name: Misty's Tentacool
+  nationalPokedexNumber: 72
+  number: '79'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, OWNERS_POKEMON]
+  evolvesTo: [Misty's Tentacruel]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [W, C]
+    name: Crystal Beam
+    damage: '20'
+    text: Flip a coin. If heads, your opponent can't attach Energy cards to the Defending
+      Pokémon during his or her next turn.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-80
+  pioId: unnumbered-80
+  enumId: LT__SURGE_S_JOLTEON_80
+  name: Lt. Surge's Jolteon
+  nationalPokedexNumber: 135
+  number: '80'
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, OWNERS_POKEMON, STAGE1]
+  evolvesFrom: Lt. Surge's Eevee
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [L, C]
+    name: High Voltage
+    damage: '20'
+    text: Flip a coin. If heads, your opponent can't play Trainer cards during his
+      or her next turn.
+  - cost: [L, L, L]
+    name: Thunder Flare
+    damage: 30+
+    text: Does 30 damage plus 10 damage times the number of damage counters on Lt.
+      Surge's Jolteon, then flip a coin. If tails, Lt. Surge's Jolteon does 30 damage
+      to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-81
+  pioId: unnumbered-81
+  enumId: BLAINE_S_GROWLITHE_81
+  name: Blaine's Growlithe
+  nationalPokedexNumber: 58
+  number: '81'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, OWNERS_POKEMON]
+  evolvesTo: [Blaine's Arcanine]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Shake
+    damage: '10'
+    text: If your opponent has any Benched Pokémon, he or she chooses 1 of them and
+      switches it with the Defending Pokémon. (Do the damage before switching the
+      Pokémon.)
+  - cost: [R, C]
+    name: Fire Tackle
+    damage: '30'
+    text: Blaine's Growlithe does 10 damage to itself.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Atsuko Nishida
+- id: 116-82
+  pioId: unnumbered-82
+  enumId: MANKEY_82
+  name: Mankey
+  nationalPokedexNumber: 56
+  number: '82'
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Primeape]
+  hp: 30
+  retreatCost: 0
+  abilities:
+  - type: Pokémon Power
+    name: Peek
+    text: 'Once during your turn (before your attack), you may look at one of the
+      following: the top card of either player''s deck, a random card from your opponent''s
+      hand, or one of either player''s Prizes. This power can''t be used if Mankey
+      is Asleep, Confused, or Paralyzed.'
+  moves:
+  - cost: [C]
+    name: Scratch
+    damage: '10'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-83
+  pioId: unnumbered-83
+  enumId: BULBASAUR_83
+  name: Bulbasaur
+  nationalPokedexNumber: 1
+  number: '83'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Ivysaur]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [G, G]
+    name: Leech Seed
+    damage: '20'
+    text: Unless all damage from this attack is prevented, you may remove 1 damage
+      counter from Bulbasaur.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Yuuki Tanaka
+- id: 116-84
+  pioId: unnumbered-84
+  enumId: GYARADOS_84
+  name: Gyarados
+  nationalPokedexNumber: 130
+  number: '84'
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Magikarp
+  hp: 100
+  retreatCost: 3
+  moves:
+  - cost: [W, W, W]
+    name: Dragon Rage
+    damage: '50'
+  - cost: [W, W, W, W]
+    name: Bubblebeam
+    damage: '40'
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  weaknesses:
+  - type: G
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Ryouichi Abe
+- id: 116-85
+  pioId: unnumbered-85
+  enumId: MAGIKARP_85
+  name: Magikarp
+  nationalPokedexNumber: 129
+  number: '85'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Gyarados]
+  hp: 30
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Tackle
+    damage: '10'
+  - cost: [W]
+    name: Flail
+    damage: 10x
+    text: Does 10 damage times the number of damage counters on Magikarp.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Yuka Matsubara
+- id: 116-86
+  pioId: unnumbered-86
+  enumId: POLIWAG_86
+  name: Poliwag
+  nationalPokedexNumber: 60
+  number: '86'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Poliwhirl]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Water Gun
+    damage: 10+
+    text: Does 10 damage plus 10 more damage for each [W] Energy attached to Poliwag
+      but not used to pay for this attack's Energy cost. Extra [W] Energy after the
+      2nd doesn't count.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Hiroyuki Sasaki
+- id: 116-87
+  pioId: unnumbered-87
+  enumId: PIKACHU_87
+  name: Pikachu
+  nationalPokedexNumber: 25
+  number: '87'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Gnaw
+    damage: '10'
+  - cost: [L, C]
+    name: Thunder Jolt
+    damage: '30'
+    text: Flip a coin. If tails, Pikachu does 10 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Mina Akuhara
+- id: 116-88
+  pioId: unnumbered-88
+  enumId: KOFFING_88
+  name: Koffing
+  nationalPokedexNumber: 109
+  number: '88'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Weezing]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [G, G]
+    name: Foul Gas
+    text: Flip a coin. If heads, the Defending Pokémon is now Poisoned; if tails,
+      it is now Confused.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Natsu Sato
+- id: 116-89
+  pioId: unnumbered-89
+  enumId: CHARMANDER_89
+  name: Charmander
+  nationalPokedexNumber: 4
+  number: '89'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Charmeleon]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Scratch
+    damage: '10'
+  - cost: [R, C]
+    name: Ember
+    damage: '30'
+    text: Discard 1 [R] Energy card attached to Charmander in order to use this attack.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  artist: Tsukasa Hosono
+- id: 116-90
+  pioId: unnumbered-90
+  enumId: ARTICUNO_90
+  name: Articuno
+  nationalPokedexNumber: 144
+  number: '90'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [W, W, W]
+    name: Freeze Dry
+    damage: '30'
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  - cost: [W, W, W, W]
+    name: Blizzard
+    damage: '50'
+    text: Flip a coin. If heads, this attack does 10 damage to each of your opponent's
+      Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched
+      Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Yui Tanaka
+- id: 116-91
+  pioId: unnumbered-91
+  enumId: SQUIRTLE_91
+  name: Squirtle
+  nationalPokedexNumber: 7
+  number: '91'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Wartortle]
+  hp: 40
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Bubble
+    damage: '10'
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  - cost: [W, C]
+    name: Withdraw
+    text: Flip a coin. If heads, prevent all damage done to Squirtle during your opponent's
+      next turn. (Any other effects of attacks still happen.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+  artist: Miyuki Ogino
+- id: 116-92
+  pioId: unnumbered-92
+  enumId: CHANSEY_92
+  name: Chansey
+  nationalPokedexNumber: 113
+  number: '92'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Blissey]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Scrunch
+    text: Flip a coin. If heads, prevent all damage done to Chansey during your opponent's
+      next turn. (Any other effects of attacks still happen.)
+  - cost: [C, C, C, C]
+    name: Double-edge
+    damage: '80'
+    text: Chansey does 80 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: P
+    value: '-30'
+  rarity: Promo
+  artist: Kaori Samoya
+- id: 116-93
+  pioId: unnumbered-93
+  enumId: MOLTRES_93
+  name: Moltres
+  nationalPokedexNumber: 146
+  number: '93'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Wildfire
+    text: You may discard any number of [R] Energy cards attached to Moltres when
+      you use this attack. If you do, discard that many cards from the top of your
+      opponent's deck.
+  - cost: [R, R, R, R]
+    name: Dive Bomb
+    damage: '80'
+    text: Flip a coin. If tails, this attack does nothing.
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-94
+  pioId: unnumbered-94
+  enumId: ARTICUNO_94
+  name: Articuno
+  nationalPokedexNumber: 144
+  number: '94'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [W, W, W]
+    name: Freeze Dry
+    damage: '30'
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  - cost: [W, W, W, W]
+    name: Blizzard
+    damage: '50'
+    text: Flip a coin. If heads, this attack does 10 damage to each of your opponent's
+      Benched Pokémon. If tails, this attack does 10 damage to each of your own Benched
+      Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-95
+  pioId: unnumbered-95
+  enumId: ZAPDOS_95
+  name: Zapdos
+  nationalPokedexNumber: 145
+  number: '95'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 80
+  retreatCost: 2
+  moves:
+  - cost: [L, L, L, L]
+    name: Thunderstorm
+    damage: '40'
+    text: For each of your opponent's Benched Pokémon, flip a coin. If heads, this
+      attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance
+      for Benched Pokémon.) Then, Zapdos does 10 damage times the number of tails
+      to itself.
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Ken Sugimori
+- id: 116-96
+  pioId: unnumbered-96
+  enumId: JYNX_96
+  name: Jynx
+  nationalPokedexNumber: 124
+  number: '96'
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesFrom: Smoochum
+  evolvesTo: [Rougella]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Ice Punch
+    damage: 10
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  - cost: [W, W]
+    name: Cold Breath
+    damage: 20
+    text: Flip a coin. If heads, the Defending Pokémon is now Asleep.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-97
+  pioId: unnumbered-97
+  enumId: EEVEE_97
+  name: Eevee
+  nationalPokedexNumber: 133
+  number: '97'
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Vaporeon, Jolteon, Flareon, Sylveon, Espeon, Umbreon, Leafeon, Glaceon]
+  hp: 50
+  retreatCost: 1
+  abilities:
+  - type: Pokémon Power
+    name: Energy Evolution
+    text: Whenever you attach an Energy card to Eevee, flip a coin. If heads, search
+      your deck for a card that evolves from Eevee that is the same type as the Energy
+      card you attached to Eevee. Attach that card to Eevee. This counts as evolving
+      Eevee. Shuffle your deck afterward. This power can't be used if Eevee is Asleep,
+      Confused, or Paralyzed.
+  moves:
+  - cost: [C]
+    name: Smash Kick
+    damage: '10'
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: P
+    value: '-30'
+  rarity: Promo
+  artist: Naoyo Kimura
+- id: 116-98
+  pioId: unnumbered-98
+  enumId: SUNKERN_98
+  name: Sunkern
+  nationalPokedexNumber: 191
+  number: '98'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Sunflora]
+  hp: 40
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Growth
+    text: Flip a coin. If heads, you may attach up to 2 [G] Energy cards from your
+      hand to Sunkern.
+  - cost: [G, G, G]
+    name: Mega Drain
+    damage: '30'
+    text: Remove a number of damage counters from Sunkern equal to half the damage
+      done to the Defending Pokémon (after applying Weakness and Resistance) (rounded
+      up to the nearest 10). If Sunkern has fewer damage counters than that, remove
+      all of them.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-99
+  pioId: unnumbered-99
+  enumId: HOPPIP_99
+  name: Hoppip
+  nationalPokedexNumber: 187
+  number: '99'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Skiploom]
+  hp: 30
+  retreatCost: 0
+  moves:
+  - cost: [G]
+    name: Rolling Tackle
+    damage: '20'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+  artist: Kagemaru Himeno
+- id: 116-100
+  pioId: unnumbered-100
+  enumId: BIRTHDAY_PIKACHU_100
+  name: Birthday Pikachu
+  nationalPokedexNumber: 25
+  number: '100'
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesFrom: Pichu
+  evolvesTo: [Raichu]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [L, L]
+    name: Birthday Surprise
+    damage: 30+
+    text: If it's not your birthday, this attack does 30 damage. If it is your birthday,
+      flip a coin. If heads, this attack does 30 damage plus 50 more damage; if tails,
+      this attack does 30 damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: Kagemaru Himeno
+
+
+
+
+
+
+

--- a/Pokemon Unnumbered Promos List.txt
+++ b/Pokemon Unnumbered Promos List.txt
@@ -1,0 +1,111 @@
+
+https://bulbapedia.bulbagarden.net/wiki/Unnumbered_Promotional_cards_(TCG)/1996-2005
+https://bulbapedia.bulbagarden.net/wiki/Intro_Pack_(TCG)
+https://bulbapedia.bulbagarden.net/wiki/Intro_Pack_Neo_(TCG)
+
+Japanese Unnumbered Promos #1-68 (New to TCGOne) 
+
+Slowpoke (Playmat promo)    
+Imakuni? (CoroCoro promo)    
+Meowth (CoroCoro promo)   
+Hungry Snorlax    
+Jynx (CoroCoro promo)  
+Cubone (CoroCoro promo)   
+Kangaskhan (Garura Parent/Child promo) 
+Diglett (Asobikata promo) 
+Dugtrio (Asobikata promo)   
+Dragonite (Pokémon Card GB promo) 
+Magikarp (University promo) 
+Ancient Mew   
+Giovanni’s Nidoking (CoroCoro promo)   
+Koga’s Ninja Gym (CoroCoro promo)    
+Exeggutor (Tropical Mega Battle Promo)  
+Tropical Wind (Tropical Mega Battle Promo)   
+Hama-chan’s Slowking (CoroCoro promo) 
+Imakuni’s Doduo (Gym Challenge) (JP only card)
+_____'s Chansey (Gym Challenge) (JP only card)
+Misty’s Treatment (CD promo)   
+Murkrow (Pokémon Card Trainers promo)  
+Wooper (CoroCoro promo)   
+Steelix (Pokémon Card Trainers promo)   
+Porygon (Fan Club promo)   
+Dance! Neo Imakuni? (CD promo)   
+Charizard (Premium File 2 promo)  
+Marill (ANA promo)  
+Togepi (ANA promo)   
+Unown R (CoroCoro promo)   
+Smoochum (CoroCoro promo)   
+Dunsparce (Information Pack promo)   
+Dark Ivysaur (Pokémon Card Trainers Promo)    
+Dark Venusaur (Pokémon Card Trainers Promo)    
+Great Rocket’s Mewtwo (Pokémon Card GB2 promo)   
+Lugia (Pokémon Card GB2 promo) 
+Dark Fearow (Pokémon Card GB2 promo) 
+Bellossom (Information Pack promo) 
+Shining Mew (CoroCoro promo) 
+Bulbasaur (Intro Pack 1)   
+Raichu (Intro Pack 3)
+Meowth (Intro Pack 16)  
+Ivysaur (Intro Pack 22)   
+Electabuzz (Intro Pack 26)  
+Jynx (Intro Pack 37)  
+Koffing (Intro Pack 39)   
+Wartortle (Intro Pack 3)  
+Spearow (Intro Pack 13)   
+Squirtle (Intro Pack 13)  
+Growlithe (Intro Pack 26) 
+Arcanine (Intro Pack 32)
+Magmar (Intro Pack 39)   
+Chikorita (Intro Pack Neo 1)  
+Sunkern (Intro Pack Neo 2) 
+Teddiursa (Intro Pack Neo 8)  
+Quilava (Intro Pack Neo 13)   
+Cyndaquil (Intro Pack Neo 16)  
+Bayleef (Intro Pack Neo 24) 
+Magby (Chikorita Side Deck) 
+Geodude (Chikorita Side Deck) 
+Skarmony (Chikorita Side Deck) 
+Marill (Intro Pack Neo 2)  
+Hoothoot (Intro Pack Neo 3) 
+Croconaw (Intro Pack Neo 4) 
+Remoraid (Intro Pack Neo 10) 
+Totodile (Intro Pack Neo 16) 
+Qwilfish (Intro Pack Neo 24) 
+Pichu (Totodile Side deck)  
+Abra (Totodile Side Deck) 
+
+Alternate Artwork Promos (#69-100)
+
+-	Venusaur		Trade Please campaign (February 10-July 31, 1998)  
+—	Charizard		Trade Please campaign (February 10-July 31, 1998) 
+—	Blastoise               Trade Please campaign (February 10-July 31, 1998) 
+—	Brock's Onix		CoroCoro Comic March 1998 issue insert (February 15, 1998) 
+—	Misty's Staryu	        CoroCoro Comic March 1998 issue insert (February 15, 1998) 
+-	Farfetch'd		CoroCoro Comic April 1998 issue insert (March 15, 1998) 
+—	Lt. Surge's Electabuzz	CoroCoro Comic August 1998 issue insert (July 15, 1998) 
+—	Erika's Dratini		CoroCoro Comic August 1998 issue insert (July 15, 1998) 
+—	Brock's Mankey		CoroCoro Comic December 1998 issue insert (November 15, 1998) 
+—	Erika's Bulbasaur	CoroCoro Comic December 1998 issue insert (November 15, 1998) 
+—	Misty's Tentacool	CoroCoro Comic December 1998 issue insert (November 15, 1998) 
+—	Lt. Surge's Jolteon	CoroCoro Comic December 1998 issue insert (November 15, 1998) 
+—	Blaine's Growlithe	CoroCoro Comic March 1999 issue insert (February 15, 1999) 
+—	Mankey	        	How I Became a Pokémon Card Vol. 1 insert (May 22, 1999)
+—	Bulbasaur	        CoroCoro Best Photo Contest 
+—	Gyarados		CoroCoro Best Photo Contest 
+—	Magikarp		CoroCoro Best Photo Contest 
+—	Poliwag	        	CoroCoro Best Photo Contest 
+—	Pikachu	        	CoroCoro Best Photo Contest 
+—	Koffing	        	64 Mario Stadium Best Photo Contest 
+—	Charmander		64 Mario Stadium Best Photo Contest 
+—	Articuno		64 Mario Stadium Best Photo Contest 
+—	Squirtle		64 Mario Stadium Best Photo Contest 
+—	Chansey	        	64 Mario Stadium Best Photo Contest 
+—	Moltres [Phone card]	Tropical Mega Battle: Dugtrio Team Battle 
+—	Articuno [Phone card]	Tropical Mega Battle: Dugtrio Team Battle 
+—	Zapdos [Phone card]	Tropical Mega Battle: Dugtrio Team Battle 
+—	Jynx	        	How I Became a Pokémon Card Vol. 3 insert (January 22, 2000) 
+—	Eevee	                Neo Premium File 2 
+—	Sunkern	                How I Became a Pokémon Card Vol. 4 insert (August 23, 2000) 
+—	Hoppip	                How I Became a Pokémon Card Vol. 5 insert (July 23, 2001) 
+—	Birthday Pikachu	How I Became a Pokémon Card Vol. 6 insert (September 23, 2001) 
+


### PR DESCRIPTION
The YAML contains all the meta information of the cards.

The other TXT document is a helpful clarifying aid to disambiguate which Promo is which. It tells what Promotion it is from, for example CoroCoro Comic April 1998 issue insert.  Also included in it are the bulbapedia links to the cards/attacks/artwork themselves